### PR TITLE
rust: add a sieve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/rust/target
+/rust/Cargo.lock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "rust"
-version = "0.1.0"
+name = "sieve"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,0 +1,7 @@
+all: tests sieve
+
+sieve:
+	cargo build
+
+tests:
+	cargo test

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,77 @@
+//struct Primes {
+    //stream: &mut dyn Iterator<Item=u32>,
+//}
+
+//impl Primes {
+    //fn new() -> Primes {
+        //Primes { stream: NaturalNumbers::new(2) }
+    //}
+//}
+
+//impl Iterator for Primes {
+    //type Item = u32;
+
+    //fn next(&mut self) -> Option<Self::Item> {
+        //let val = self.stream.next();
+        //self.stream = self.stream.filter(|x| x % val != 0);
+        //Some(val)
+    //}
+//}
+
+struct NaturalNumbers {
+    cur: u32,
+}
+
+impl NaturalNumbers {
+    fn new(start: u32) -> NaturalNumbers {
+        NaturalNumbers { cur: start }
+    }
+}
+
+impl Iterator for NaturalNumbers {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO: handle overflow, won't panic in non-debug mode
+        let val = self.cur;
+        self.cur += 1;
+        Some(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn natural_numbers_generation() {
+        let mut nums = NaturalNumbers::new(2);
+
+        assert_eq!(nums.next(), Some(2));
+        assert_eq!(nums.next(), Some(3));
+        assert_eq!(nums.next(), Some(4));
+        assert_eq!(nums.next(), Some(5));
+
+        let mut nums = NaturalNumbers::new(100);
+
+        assert_eq!(nums.next(), Some(100));
+        assert_eq!(nums.next(), Some(101));
+        assert_eq!(nums.next(), Some(102));
+    }
+
+    //#[test]
+    //fn primes_generation() {
+        //let mut primes = Primes::new();
+
+        //assert_eq!(primes.next(), Some(2));
+        //assert_eq!(primes.next(), Some(3));
+        //assert_eq!(primes.next(), Some(5));
+        //assert_eq!(primes.next(), Some(7));
+        //assert_eq!(primes.next(), Some(11));
+        //assert_eq!(primes.next(), Some(13));
+        //assert_eq!(primes.next(), Some(17));
+        //assert_eq!(primes.next(), Some(19));
+        //assert_eq!(primes.next(), Some(23));
+        //assert_eq!(primes.next(), Some(29));
+    //}
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,7 +13,7 @@ impl Iterator for Primes {
 
     fn next(&mut self) -> Option<Self::Item> {
         let val: u32 = self.iter.next().expect("numbers stream should be infinite");
-        self.iter = Box::new(self.iter.filter(|x| x % val != 0));
+        self.iter = Box::new(self.iter.filter(move |x| x % val != 0));
         Some(val)
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,21 +1,20 @@
-struct Primes {
-    iter: Box<dyn Iterator<Item=u32>>,
-}
+fn primes(n: u32) -> Vec<u32> {
+    let mut vec: Vec<u32> = Vec::new();
+    // Did lose a few hours with how to have an iterator that incrementally
+    // chains more and more filters. This is the only thing that worked:
+    //
+    // - https://users.rust-lang.org/t/multiple-staggered-filters-on-an-iterator/60959/4
+    //
+    // The learning curve for this stuff is steep as fuck x_x.
+    let mut iter: Box<dyn Iterator<Item = u32> + '_> = Box::new(NaturalNumbers::new(2));
 
-impl Primes {
-    fn new() -> Primes {
-        Primes { iter : Box::new(NaturalNumbers::new(2)) }
+    for _ in 0..n {
+        let val = iter.next().expect("unexpected EOS");
+        vec.push(val);
+        iter = Box::new(iter.filter(move |x| x % val != 0));
     }
-}
 
-impl Iterator for Primes {
-    type Item = u32;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let val: u32 = self.iter.next().expect("numbers stream should be infinite");
-        self.iter = Box::new(self.iter.filter(move |x| x % val != 0));
-        Some(val)
-    }
+    vec
 }
 
 struct NaturalNumbers {
@@ -61,17 +60,17 @@ mod tests {
 
     #[test]
     fn primes_generation() {
-        let mut primes = Primes::new();
+        let p = primes(10);
 
-        assert_eq!(primes.next(), Some(2));
-        assert_eq!(primes.next(), Some(3));
-        assert_eq!(primes.next(), Some(5));
-        assert_eq!(primes.next(), Some(7));
-        assert_eq!(primes.next(), Some(11));
-        assert_eq!(primes.next(), Some(13));
-        assert_eq!(primes.next(), Some(17));
-        assert_eq!(primes.next(), Some(19));
-        assert_eq!(primes.next(), Some(23));
-        assert_eq!(primes.next(), Some(29));
+        assert_eq!(p[0], 2);
+        assert_eq!(p[1], 3);
+        assert_eq!(p[2], 5);
+        assert_eq!(p[3], 7);
+        assert_eq!(p[4], 11);
+        assert_eq!(p[5], 13);
+        assert_eq!(p[6], 17);
+        assert_eq!(p[7], 19);
+        assert_eq!(p[8], 23);
+        assert_eq!(p[9], 29);
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,22 +1,21 @@
-//struct Primes {
-    //stream: &mut dyn Iterator<Item=u32>,
-//}
+struct Primes<I: Iterator> {
+    iter: I
+}
 
-//impl Primes {
-    //fn new() -> Primes {
-        //Primes { stream: NaturalNumbers::new(2) }
-    //}
-//}
+impl<I: Iterator> Primes<I> {
+    fn new(iter: I) -> Primes<I> {
+        Primes { iter }
+    }
+}
 
-//impl Iterator for Primes {
-    //type Item = u32;
+impl<I: Iterator> Iterator for Primes<I>
+{
+    type Item = I::Item;
 
-    //fn next(&mut self) -> Option<Self::Item> {
-        //let val = self.stream.next();
-        //self.stream = self.stream.filter(|x| x % val != 0);
-        //Some(val)
-    //}
-//}
+    fn next(&mut self) -> Option<I::Item> {
+        self.iter.next()
+    }
+}
 
 struct NaturalNumbers {
     cur: u32,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,4 @@
-fn primes(n: u32) -> Vec<u32> {
+pub fn primes(n: u32) -> Vec<u32> {
     let mut vec: Vec<u32> = Vec::new();
     // Did lose a few hours with how to have an iterator that incrementally
     // chains more and more filters. This is the only thing that worked:
@@ -6,6 +6,13 @@ fn primes(n: u32) -> Vec<u32> {
     // - https://users.rust-lang.org/t/multiple-staggered-filters-on-an-iterator/60959/4
     //
     // The learning curve for this stuff is steep as fuck x_x.
+    // Tried to model primes also as an iterator/stream, but the borrow
+    // checker defeated me at my current novice level x_x.
+    // Code very similar to this, but using a struct with the boxed type,
+    // simply didn't work, there was always some different lifetime/reference
+    // issue that I was unable to solve properly x_x.
+    // In the end it could have worked if it was easy to declare a trait that is
+    // an Iterator + Clone, but it is not easy AFAIK.
     let mut iter: Box<dyn Iterator<Item = u32> + '_> = Box::new(NaturalNumbers::new(2));
 
     for _ in 0..n {
@@ -31,7 +38,6 @@ impl Iterator for NaturalNumbers {
     type Item = u32;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO: handle overflow, won't panic in non-debug mode
         let val = self.cur;
         self.cur += 1;
         Some(val)
@@ -60,8 +66,18 @@ mod tests {
 
     #[test]
     fn primes_generation() {
+        let p = primes(0);
+
+        assert_eq!(p.len(), 0);
+
+        let p = primes(1);
+
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0], 2);
+
         let p = primes(10);
 
+        assert_eq!(p.len(), 10);
         assert_eq!(p[0], 2);
         assert_eq!(p[1], 3);
         assert_eq!(p[2], 5);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,19 +1,20 @@
-struct Primes<I: Iterator> {
-    iter: I
+struct Primes {
+    iter: Box<dyn Iterator<Item=u32>>,
 }
 
-impl<I: Iterator> Primes<I> {
-    fn new(iter: I) -> Primes<I> {
-        Primes { iter }
+impl Primes {
+    fn new() -> Primes {
+        Primes { iter : Box::new(NaturalNumbers::new(2)) }
     }
 }
 
-impl<I: Iterator> Iterator for Primes<I>
-{
-    type Item = I::Item;
+impl Iterator for Primes {
+    type Item = u32;
 
-    fn next(&mut self) -> Option<I::Item> {
-        self.iter.next()
+    fn next(&mut self) -> Option<Self::Item> {
+        let val: u32 = self.iter.next().expect("numbers stream should be infinite");
+        self.iter = Box::new(self.iter.filter(|x| x % val != 0));
+        Some(val)
     }
 }
 
@@ -58,19 +59,19 @@ mod tests {
         assert_eq!(nums.next(), Some(102));
     }
 
-    //#[test]
-    //fn primes_generation() {
-        //let mut primes = Primes::new();
+    #[test]
+    fn primes_generation() {
+        let mut primes = Primes::new();
 
-        //assert_eq!(primes.next(), Some(2));
-        //assert_eq!(primes.next(), Some(3));
-        //assert_eq!(primes.next(), Some(5));
-        //assert_eq!(primes.next(), Some(7));
-        //assert_eq!(primes.next(), Some(11));
-        //assert_eq!(primes.next(), Some(13));
-        //assert_eq!(primes.next(), Some(17));
-        //assert_eq!(primes.next(), Some(19));
-        //assert_eq!(primes.next(), Some(23));
-        //assert_eq!(primes.next(), Some(29));
-    //}
+        assert_eq!(primes.next(), Some(2));
+        assert_eq!(primes.next(), Some(3));
+        assert_eq!(primes.next(), Some(5));
+        assert_eq!(primes.next(), Some(7));
+        assert_eq!(primes.next(), Some(11));
+        assert_eq!(primes.next(), Some(13));
+        assert_eq!(primes.next(), Some(17));
+        assert_eq!(primes.next(), Some(19));
+        assert_eq!(primes.next(), Some(23));
+        assert_eq!(primes.next(), Some(29));
+    }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
I went with the classical algorithm:

1 - You have a infinite stream of natural numbers starting at 2
2 - You get the first one, it is prime (2), and now create a stream that filters out any number divisible by the prime number
3 - Repeat as much as you want to get the next prime, chaining filters

So the overall abstraction is the stream, in Rust case called Iterator. That is why I centered stuff around having a current iterator that is dynamically updated with a version of itself with a new filter added.

I tried to make primes also be an iterator itself, like the natural numbers iterator (the infinite stream of numbers), but the type system + borrow checker + lifetime stuff using 'static and 'a etc just won me over, it will take me much more time to properly understand this lifetime stuff well enough.

To play around just:

```sh
cd rust
make
./target/debug/sieve 1
./target/debug/sieve 10
./target/debug/sieve 100
```

The main disadvantage, besides performance, of the way Im chaining calls is that for large numbers of prime you will get an stack overflow since we end up with a very deep call graph (filter calling filter calling filter and so goes on).